### PR TITLE
feat: modernize demo UI visual style

### DIFF
--- a/apps/web-ui/src/main.tsx
+++ b/apps/web-ui/src/main.tsx
@@ -4006,6 +4006,7 @@ function App() {
             <p className="eyebrow">Secure A2A Control Plane</p>
             <h1>Secure Agent Orchestration Gateway</h1>
             <p className="subtitle">Import external agents through Agent Cards and govern execution with scoped JWTs, policy, and audit.</p>
+            <div className="menu-hint">✨ Demo mode: use tabs + quick scenarios to tour trust, routing, and runtime controls.</div>
           </div>
           <div className="topbar-actions">
             {isUserAuthenticated ? (

--- a/apps/web-ui/src/styles.css
+++ b/apps/web-ui/src/styles.css
@@ -1,7 +1,13 @@
 :root {
-  color: #172026;
-  background: #f4f6f7;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e8eef5;
+  background: radial-gradient(circle at top left, #1d2842 0%, #0c1324 45%, #080c18 100%);
+  font-family: Inter, "SF Pro Display", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --surface: rgba(12, 20, 36, 0.72);
+  --surface-strong: rgba(16, 27, 48, 0.9);
+  --border: rgba(121, 164, 255, 0.24);
+  --text-subtle: #9fb5d9;
+  --accent: #6ea8fe;
+  --accent-2: #8f7dff;
 }
 
 * {
@@ -10,6 +16,8 @@
 
 body {
   margin: 0;
+  min-height: 100vh;
+  background: transparent;
 }
 
 button,
@@ -33,10 +41,11 @@ textarea {
 .workspace {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   min-height: 0;
-  padding: 18px 24px;
-  background: #fbfcfd;
+  padding: 20px 24px;
+  background: linear-gradient(170deg, rgba(12, 20, 36, 0.75), rgba(7, 12, 24, 0.95));
+  backdrop-filter: blur(18px);
 }
 
 .topbar {
@@ -48,7 +57,7 @@ textarea {
 
 .eyebrow {
   margin: 0 0 5px;
-  color: #47626f;
+  color: var(--text-subtle);
   font-size: 13px;
   font-weight: 700;
   text-transform: uppercase;
@@ -62,8 +71,9 @@ p {
 
 h1 {
   margin-bottom: 0;
-  font-size: 28px;
-  line-height: 1.15;
+  font-size: 30px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
 }
 
 h2 {
@@ -74,17 +84,17 @@ h2 {
 .subtitle {
   max-width: 760px;
   margin: 8px 0 0;
-  color: #526b76;
+  color: #b1c2de;
   font-size: 14px;
   line-height: 1.45;
 }
 
 .status {
-  border: 1px solid #bed3c3;
+  border: 1px solid rgba(132, 245, 169, 0.4);
   border-radius: 999px;
   padding: 7px 12px;
-  color: #1d5a38;
-  background: #eef8f0;
+  color: #befdd4;
+  background: rgba(28, 88, 60, 0.45);
   font-size: 13px;
   font-weight: 700;
   white-space: nowrap;
@@ -110,11 +120,11 @@ h2 {
 }
 
 .secondary-button {
-  border: 1px solid #b8c7cd;
+  border: 1px solid var(--border);
   border-radius: 999px;
   padding: 7px 12px;
-  color: #2d4650;
-  background: #f7fafb;
+  color: #d8e4fb;
+  background: rgba(31, 49, 82, 0.72);
   font-size: 13px;
   font-weight: 800;
   white-space: nowrap;
@@ -123,9 +133,9 @@ h2 {
 
 .secondary-button.active-panel-button {
   color: #ffffff;
-  background: #235789;
-  border-color: #235789;
-  box-shadow: 0 0 0 3px rgba(35, 87, 137, 0.12);
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border-color: transparent;
+  box-shadow: 0 6px 22px rgba(110, 168, 254, 0.28);
 }
 
 .health-summary {
@@ -181,26 +191,26 @@ h2 {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  border-bottom: 1px solid #d7e0e4;
+  border-bottom: 1px solid var(--border);
   padding-bottom: 10px;
 }
 
 .product-tabs button {
-  border: 1px solid #c7d2d8;
+  border: 1px solid var(--border);
   border-radius: 8px 8px 0 0;
   padding: 10px 14px;
-  color: #384b53;
-  background: #f7fafb;
+  color: #bfd1f0;
+  background: rgba(19, 30, 52, 0.75);
   font-size: 13px;
   font-weight: 800;
   cursor: pointer;
 }
 
 .product-tabs button.active {
-  border-color: #235789;
+  border-color: transparent;
   color: #ffffff;
-  background: #235789;
-  box-shadow: 0 3px 0 #d1495b;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  box-shadow: 0 8px 20px rgba(111, 125, 255, 0.35);
 }
 
 .control-panel {
@@ -209,10 +219,11 @@ h2 {
   gap: 18px;
   min-height: 0;
   overflow: auto;
-  border: 1px solid #d7e0e4;
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
   padding: 18px;
-  background: #ffffff;
+  background: var(--surface);
+  box-shadow: inset 0 1px 0 rgba(197, 221, 255, 0.08), 0 12px 40px rgba(0, 0, 0, 0.28);
 }
 
 .panel-header {
@@ -452,8 +463,8 @@ h2 {
   border: 1px solid #c7d2d8;
   border-radius: 999px;
   padding: 7px 11px;
-  color: #384b53;
-  background: #f7fafb;
+  color: #bfd1f0;
+  background: rgba(19, 30, 52, 0.75);
   font-size: 12px;
   font-weight: 800;
   cursor: pointer;
@@ -4651,4 +4662,16 @@ summary:focus-visible,
   .visual-security-timeline {
     scroll-margin-top: 24px;
   }
+}
+
+.menu-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(16, 27, 48, 0.76);
+  color: var(--text-subtle);
+  font-size: 12px;
 }


### PR DESCRIPTION
### Motivation
- Improve demo-readiness and visual clarity by moving the demo UI away from a flat, pale appearance toward a modern, high-contrast glass-like dark theme for 2026-style presentations. 
- Increase navigation and action affordance so demo participants can quickly discover tabs, quick-scenarios, and runtime controls. 
- Provide a small in-product hint to orient users during walkthroughs without changing core functionality.

### Description
- Updated visual system variables and palettes in `apps/web-ui/src/styles.css` to introduce a dark glass surface, new accent tokens, and subtle depth (`--surface`, `--border`, `--accent`, `--accent-2`).
- Restyled workspace and control surfaces with backdrop blur, updated spacing/typography, rounded panel radii, and elevated panel shadows to improve perceived hierarchy. 
- Upgraded interactive controls by changing button and tab styles to gradient active states, refined border usage, and stronger focus/halo shadows for clearer navigation. 
- Added a compact demo guidance chip by inserting a `div.menu-hint` into `apps/web-ui/src/main.tsx` and providing `.menu-hint` CSS for the header to surface demo orientation.

### Testing
- Ran the project build with `npm --prefix apps/web-ui run build`, which executed TypeScript checks and `vite build` and completed successfully with generated `dist` assets. 
- Performed a local smoke check of the built UI bundle to verify CSS/JS compiled without type errors and the new styles are included in the output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff92bf59a083299afdfe4355340146)