### PR TITLE
docs: reinforce orchestrator-agnostic positioning and add roadmap verification

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -376,3 +376,8 @@ Manual production demo path:
 3. Onboard each external connector agent using its public HTTPS Railway URL.
 4. Run Connector Test Center validation tests.
 5. Open Security Timeline and confirm policy, token, runtime, and audit proof.
+
+
+## Deployment framing
+
+Deployment examples in this document can be vendor-specific for operability, but Ogen contracts and policy boundaries remain vendor-neutral as defined in [`docs/orchestrator-agnostic-roadmap.md`](./orchestrator-agnostic-roadmap.md).

--- a/docs/ogen-product-identity.md
+++ b/docs/ogen-product-identity.md
@@ -31,6 +31,8 @@ Use the unified tagline by default in README, demo, LinkedIn, and product copy. 
 
 ## Positioning
 
+Ogen is orchestrator-agnostic, as defined in [`docs/orchestrator-agnostic-roadmap.md`](./orchestrator-agnostic-roadmap.md).
+
 Ogen anchors every enterprise AI agent action to:
 
 - verified user identity
@@ -125,6 +127,7 @@ Ogen is a Secure A2A Gateway for identity-bound, policy-governed enterprise AI a
 I call it Ogen.
 
 AI agents are starting to act inside real enterprise systems — Jira, ServiceNow, GitHub, Monday, internal APIs.
+ServiceNow, Microsoft, and MCP examples are examples only; Ogen contracts and policy boundaries remain vendor-neutral and orchestrator-agnostic.
 
 But before giving them keys to the building, every action needs to be anchored to identity, permissions, consent, policy, and audit.
 

--- a/docs/sdk-readiness-contracts.md
+++ b/docs/sdk-readiness-contracts.md
@@ -158,6 +158,18 @@ Required proof fields and invariants:
 
 AI can interpret and suggest routing. Ogen validates, applies policy, and authorizes.
 
+## Orchestrator-agnostic metadata and policy normalization
+
+The SDK contracts must align with [`docs/orchestrator-agnostic-roadmap.md`](./orchestrator-agnostic-roadmap.md). Connector metadata and decision flows must include and preserve:
+
+- `approvalMode`
+- `resourceSensitivity`
+- `fieldClass`
+- `actionConstraints`
+- normalized action categories policy
+
+These requirements are contract-level inputs for safe authorization and audit proof. Vendor-specific adapters may map native fields, but they must normalize into this shared Ogen policy shape before authorization decisions.
+
 ## Certification Checklist
 
 A future SDK connector must pass:

--- a/docs/v2-platform-foundation.md
+++ b/docs/v2-platform-foundation.md
@@ -55,6 +55,12 @@ V1 proves:
 - proof / execution gate stack
 - Jira, ServiceNow, and GitHub reference connector runtimes
 
+## Orchestrator-agnostic strategy
+
+Ogen V2 remains orchestrator-agnostic by design. The concrete roadmap, capability boundaries, and migration posture are defined in [`docs/orchestrator-agnostic-roadmap.md`](./orchestrator-agnostic-roadmap.md).
+
+Vendor or platform examples may appear in implementation notes, but the trust contracts, policy model, and security boundaries stay orchestrator-neutral.
+
 ## V2 Phases
 
 ### Phase 0  V1 Closeout / Branch Hygiene

--- a/scripts/verify-v2-plan.ts
+++ b/scripts/verify-v2-plan.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 const path = "docs/v2-platform-foundation.md";
 const stateInventoryPath = "docs/v2-state-inventory.md";
+const orchestratorAgnosticRoadmapPath = "docs/orchestrator-agnostic-roadmap.md";
 const sharedPath = "packages/shared/src/index.ts";
 const deploymentPath = "docs/deployment.md";
 const packageJsonPath = "package.json";
@@ -76,12 +77,19 @@ if (!existsSync(path)) {
     "SERVICENOW_INSTANCE_URL",
     "ServiceNow credentials live only in the external adapter",
     "V2 Implementation Checklist",
-    "What Remains V3+"
+    "What Remains V3+",
+    "Orchestrator-agnostic strategy",
+    "docs/orchestrator-agnostic-roadmap.md"
   ]) {
     if (!doc.includes(phrase)) {
       fail(`V2 plan missing required phrase: ${phrase}`);
     }
   }
+}
+
+
+if (!existsSync(orchestratorAgnosticRoadmapPath)) {
+  fail(`${orchestratorAgnosticRoadmapPath} should exist`);
 }
 
 if (!existsSync(stateInventoryPath)) {
@@ -139,7 +147,9 @@ if (!existsSync(deploymentPath)) {
   for (const phrase of [
     "Auth0 is for real browser user identity",
     "Reference A2A Token Issuer",
-    "they do not validate Auth0 directly"
+    "they do not validate Auth0 directly",
+    "vendor-specific",
+    "vendor-neutral"
   ]) {
     if (!deployment.includes(phrase)) {
       fail(`deployment docs missing required phrase: ${phrase}`);
@@ -271,6 +281,26 @@ if (!existsSync(packageJsonPath)) {
   }
   if (!packageJson.scripts?.["verify:v2-plan"]?.includes("verify:audit-viewer-boundary")) {
     fail("verify:v2-plan should run verify:audit-viewer-boundary");
+  }
+}
+
+
+const coreDocsThatMustReferenceRoadmap = [
+  path,
+  "docs/ogen-product-identity.md",
+  "docs/sdk-readiness-contracts.md",
+  deploymentPath
+];
+
+for (const coreDocPath of coreDocsThatMustReferenceRoadmap) {
+  if (!existsSync(coreDocPath)) {
+    fail(`${coreDocPath} should exist`);
+    continue;
+  }
+
+  const content = readFileSync(coreDocPath, "utf8");
+  if (!content.includes("orchestrator-agnostic-roadmap.md")) {
+    fail(`${coreDocPath} should reference docs/orchestrator-agnostic-roadmap.md to avoid orphan docs`);
   }
 }
 


### PR DESCRIPTION
### Motivation

- Make the V2 narrative explicitly orchestrator-agnostic and surface the new orchestrator-agnostic roadmap so core docs do not diverge or become orphaned. 
- Ensure SDK readiness contracts require normalized, orchestrator-agnostic metadata fields used by policy and authorization. 
- Clarify that deployment examples may be vendor-specific while contracts and policy boundaries remain vendor-neutral.

### Description

- Added an **Orchestrator-agnostic strategy** section with a direct link to `docs/orchestrator-agnostic-roadmap.md` in `docs/v2-platform-foundation.md`.
- Updated `docs/ogen-product-identity.md` to state `Ogen is orchestrator-agnostic` and clarified that ServiceNow/Microsoft/MCP mentions are examples only (with a roadmap link).
- Extended `docs/sdk-readiness-contracts.md` to require `approvalMode`, `resourceSensitivity`, `fieldClass`, `actionConstraints`, and normalized action categories policy mapped to the orchestrator-agnostic roadmap.
- Added a short framing note to `docs/deployment.md` that deployment examples can be vendor-specific while contracts/policy boundaries remain vendor-neutral (linked to the roadmap).
- Updated `scripts/verify-v2-plan.ts` to require the presence of `docs/orchestrator-agnostic-roadmap.md` and to verify that a set of core docs (`docs/v2-platform-foundation.md`, `docs/ogen-product-identity.md`, `docs/sdk-readiness-contracts.md`, and `docs/deployment.md`) reference it so the roadmap is not orphaned.
- Left `package.json` verification entrypoint intact and preserved the `verify:v2-plan` script behavior so the new checks run as part of the existing verify chain.

### Testing

- Ran `npm run verify:v2-plan`; the updated `scripts/verify-v2-plan.ts` checks passed and the top-level verification step executed.
- The full `verify:v2-plan` chain did not complete in this environment because `verify:platform-state-onboarding` failed with `Error: Cannot find module 'pg'`, which is an unrelated environment dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fe1afc248329bcc4d580116485d9)